### PR TITLE
ENG-311: Test nonzero decimal offset

### DIFF
--- a/tests/ERC4626BufferedUpgradable.t.sol
+++ b/tests/ERC4626BufferedUpgradable.t.sol
@@ -13,9 +13,9 @@ import {ERC20Mock} from "tests/mock/ERC20Mock.sol";
 contract ERC4626BufferedUpgradeableConcrete is ERC4626BufferedUpgradeable {
     uint8 private decimalsOffset;
 
-    function initialize(uint8 decimalsOffset_, IERC20 _asset) public initializer {
+    function initialize(uint8 _decimalsOffset, IERC20 _asset) public initializer {
         __ERC4626Buffered_init(_asset);
-        decimalsOffset = decimalsOffset_;
+        decimalsOffset = _decimalsOffset;
     }
 
     function currentBufferEnd() external view returns (uint256) {


### PR DESCRIPTION
Follow-up with more tests to #25. Rewritten `testFeeWithBufferEnd` a bit, otherwise changes in tests should be minimal. I left `testFuzz_WithUserActions` to be run only with 0 `decimalsOffset`: probably this test could be adjusted, but I haven't figured out how. All other tests are run both with ERC4626Buffered with no `decimalsOffset`, and with `4` `decimalsOffset`.