### PR TITLE
Advance time before benchmarks

### DIFF
--- a/tests/aggregator/Benchmarks.t.sol
+++ b/tests/aggregator/Benchmarks.t.sol
@@ -67,7 +67,7 @@ contract CommonAggregatorTest is Test {
 
         advanceTimeWithGain();
         commonAggregator.deposit(amountToDeposit, alice);
-        
+
         advanceTimeWithGain();
         sharesToMint = commonAggregator.previewDeposit(BASE_AMOUNT);
         commonAggregator.mint(sharesToMint, alice);
@@ -87,7 +87,6 @@ contract CommonAggregatorTest is Test {
         uint256 sharesToWithdraw = commonAggregator.previewWithdraw(BASE_AMOUNT);
         commonAggregator.redeem(sharesToWithdraw, alice, alice);
         vm.stopPrank();
-
 
         // Update holdings state
         for (uint256 i = 0; i < 5; i++) {


### PR DESCRIPTION
To get more real-use gas benchmark, advance the time before each state changing call with a small gain in assets.