### PR TITLE
Make maxRedeem non-reverting again

### DIFF
--- a/contracts/CommonTimelocks.sol
+++ b/contracts/CommonTimelocks.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNKNOWN
 pragma solidity ^0.8.28;
 
+import {saturatingAdd} from "./Math.sol";
+
 /// @title An abstract contract which manages timelocked actions.
 /// @notice A timelocked action can be registered to be executed after the timelock passes. A registered action
 /// can be cancelled anytime.
@@ -53,7 +55,7 @@ abstract contract CommonTimelocks {
         if ($.registeredTimelocks[actionHash] != NOT_REGISTERED) {
             revert ActionAlreadyRegistered(actionHash);
         }
-        $.registeredTimelocks[actionHash] = _saturatingAdd(block.timestamp, delay);
+        $.registeredTimelocks[actionHash] = saturatingAdd(block.timestamp, delay);
     }
 
     /// @dev Removes a timelock entry for the given action if it exists and the timelock has passed.
@@ -82,15 +84,6 @@ abstract contract CommonTimelocks {
     function _getTimelocksStorage() private pure returns (TimelocksStorage storage $) {
         assembly {
             $.slot := TIMELOCKS_STORAGE_LOCATION
-        }
-    }
-
-    /// @dev Utility function for addition which returns the maximal uint256 value if the result would overflow.
-    function _saturatingAdd(uint256 a, uint256 b) private pure returns (uint256 result) {
-        if (type(uint256).max - a < b) {
-            result = type(uint256).max;
-        } else {
-            result = a + b;
         }
     }
 }

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -20,6 +20,17 @@ function checkedSub(uint256 a, uint256 b, uint256 id) pure returns (uint256 resu
     if (!success) revert SubtractionOverflow(id);
 }
 
+/// @notice Returns a+b, or type(uint256).max if it would overflow. The function never reverts.
+function saturatingAdd(uint256 a, uint256 b) pure returns (uint256 result) {
+    unchecked {
+        if (type(uint256).max - a < b) {
+            result = type(uint256).max;
+        } else {
+            result = a + b;
+        }
+    }
+}
+
 /// @notice Returns weighted average of v1 and v2, rounded down.
 /// Reverts if w1+w2 is zero, overflows uint256, or if the result overflows uint256.
 function weightedAvg(uint256 v1, uint256 w1, uint256 v2, uint256 w2) pure returns (uint256 result) {

--- a/tests/Math.t.sol
+++ b/tests/Math.t.sol
@@ -3,10 +3,18 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {mulDivWithRemainder, weightedAvg} from "../contracts/Math.sol";
+import {mulDivWithRemainder, weightedAvg, saturatingAdd} from "../contracts/Math.sol";
 
 contract MathTest is Test {
     using Math for uint256;
+
+    function test_saturatingAdd() public pure {
+        assertEq(saturatingAdd(1, 2), 3);
+        assertEq(saturatingAdd(1, type(uint256).max), type(uint256).max);
+        assertEq(saturatingAdd(0, type(uint256).max), type(uint256).max);
+        assertEq(saturatingAdd(5, type(uint256).max - 6), type(uint256).max - 1);
+        assertEq(saturatingAdd(type(uint256).max, type(uint256).max), type(uint256).max);
+    }
 
     function testFuzz_mulDivWithRemainder(uint256 a, uint256 b, uint256 c) public pure {
         c = bound(c, 1, (1 << 128));

--- a/tests/aggregator/Withdrawals.t.sol
+++ b/tests/aggregator/Withdrawals.t.sol
@@ -74,6 +74,21 @@ contract CommonAggregatorTest is Test {
         assertEq(commonAggregator.maxRedeem(alice), commonAggregator.convertToShares(90));
     }
 
+    function testMaxWithdrawAndRedeemDontRevert() public {
+        _prepareDistribution([uint256(1 << 230), uint256(1 << 230), 0], 0);
+
+        uint256 aliceInitialShares = commonAggregator.balanceOf(alice);
+
+        uint256 initialAssets = commonAggregator.totalAssets();
+        asset.mint(address(commonAggregator.getVaults()[0]), 1 << 254);
+        asset.mint(address(commonAggregator.getVaults()[2]), 1 << 255);
+
+        // Not yet updated
+        assertEq(commonAggregator.totalAssets(), 2 * (1 << 230));
+        assertEq(commonAggregator.maxWithdraw(alice), 2 * (1 << 230));
+        assertEq(commonAggregator.maxRedeem(alice), aliceInitialShares);
+    }
+
     function testSimpleWithdraw() public {
         _prepareDistribution([uint256(10), 20, 30], 5);
 


### PR DESCRIPTION
Previously, it could theoretically revert on big numbers, which was prohibited by ERC-4626 standard